### PR TITLE
fix the way cookies are set, courtesy of @max107

### DIFF
--- a/turbolinks/middleware.py
+++ b/turbolinks/middleware.py
@@ -1,8 +1,6 @@
-
-
 class TurbolinksMiddleware(object):
 
     def process_response(self, request, response):
         response['X-XHR-Current-Location'] = request.get_full_path()
-        response.set_cookie('request_method') = request.method
+        response.set_cookie('request_method', request.method)
         return response


### PR DESCRIPTION
I was unable to load the middleware as it was. This is the correct way to set django cookies according to the documentation.
